### PR TITLE
test: fix Dashboard test mocking for useEffect API calls

### DIFF
--- a/frontend/user-portal/src/pages/Dashboard.test.tsx
+++ b/frontend/user-portal/src/pages/Dashboard.test.tsx
@@ -113,8 +113,12 @@ describe('Dashboard', () => {
       email: 'test@example.com',
       fullName: 'Test User',
       onboardingCompleted: true,
+      roles: [],
     };
 
+    // Mock for useEffect call on mount
+    vi.mocked(apiClient.getCurrentUser).mockResolvedValueOnce(mockApiResponse);
+    // Mock for button click call
     vi.mocked(apiClient.getCurrentUser).mockResolvedValueOnce(mockApiResponse);
 
     render(<Dashboard />);
@@ -155,6 +159,15 @@ describe('Dashboard', () => {
   });
 
   it('should display error message when API call fails', async () => {
+    // Mock for useEffect call on mount
+    vi.mocked(apiClient.getCurrentUser).mockResolvedValueOnce({
+      userId: 'user-123',
+      email: 'test@example.com',
+      fullName: 'Test User',
+      onboardingCompleted: true,
+      roles: [],
+    });
+    // Mock for button click call - this one should fail
     vi.mocked(apiClient.getCurrentUser).mockRejectedValueOnce(new Error('Network error'));
 
     render(<Dashboard />);


### PR DESCRIPTION
## Summary

Fixed two failing tests in `Dashboard.test.tsx` by adding proper API mocking for both the useEffect call and button click call.

## Root Cause

The Dashboard component calls `apiClient.getCurrentUser()` in two places:
1. **useEffect on mount** (line 36-38) - to fetch current user with roles
2. **Test API Call button** (line 50) - when user clicks the test button

The failing tests only mocked one API call using `mockResolvedValueOnce`, so the second call would fail with undefined, causing the tests to break.

## Solution

Added proper mocking for **both** API calls in each test:
- First `mockResolvedValueOnce` for the useEffect call on mount
- Second `mockResolvedValueOnce`/`mockRejectedValueOnce` for the button click

Also added the `roles: []` property to mock responses to match the `CurrentUserResponse` type.

## Tests Fixed

- ✅ "should call API and display response when test button is clicked"
- ✅ "should display error message when API call fails"

## Verification

All tests now pass across the entire codebase:
- Backend: 187 tests ✅
- User Portal: 76 tests ✅
- Admin Portal: 16 tests ✅

## Files Changed

- `frontend/user-portal/src/pages/Dashboard.test.tsx` - Added dual mocking for both API calls

## Test Plan

- [x] Run `npm test` in user-portal - all 76 tests pass
- [x] Run `dotnet test` for backend - all 187 tests pass
- [x] Run `npm test` in admin-portal - all 16 tests pass
- [x] Verified the specific failing tests now pass
- [x] No regression in other Dashboard tests